### PR TITLE
Update chat translation logic

### DIFF
--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,5 +1,6 @@
 import os
 import io
+import re
 
 from dotenv import load_dotenv
 
@@ -99,8 +100,12 @@ async def chat(chat_request: ChatRequest, current_user=Depends(get_current_user)
     """
     Chat endpoint. Returns a WhatsApp chat response to user text sent in via WhatsApp chat
     """
-    response = translate(chat_request.text, chat_request.source_language,
-                         chat_request.target_language)
+    # Translate from English to the local language and if it returns 
+    # the same thing, then translate from the local language to English.
+    # Note: This is a temporary solution until language detection is implemented
+    response = translate(chat_request.text, "English", chat_request.local_language)
+    if re.fullmatch(f"{chat_request.text}[.?]?", response):
+        response = translate(chat_request.text, chat_request.local_language, "English")
 
     # Send message via chat
     account_sid = chat_request.twilio_sid

--- a/app/schemas/tasks.py
+++ b/app/schemas/tasks.py
@@ -39,8 +39,7 @@ class TTSResponse(BaseModel):
     audio_link: str | None = None
 
 class ChatRequest(BaseModel):
-    source_language: Language | None = None
-    target_language: Language 
+    local_language: Language 
     text: str = Field(min_length=3, max_length=200)
     from_number: str = Field(min_length=5, max_length=15)
     to_number: str = Field(min_length=5, max_length=15)

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">62%</text>
-        <text x="80" y="14">62%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>


### PR DESCRIPTION
This PR adds two-way translation to the "tasks/chat" endpoint, translating from English to the local language and if it returns the same thing, then translating from the local language to English.
This is a temporary solution until language detection is implemented.